### PR TITLE
[MyPage/aos] 로그아웃, 회원 탈퇴 후 화면 전환

### DIFF
--- a/Aos/app/src/main/java/com/avengers/nibobnebob/app/App.kt
+++ b/Aos/app/src/main/java/com/avengers/nibobnebob/app/App.kt
@@ -13,13 +13,19 @@ import dagger.hilt.android.HiltAndroidApp
 @HiltAndroidApp
 class App : Application(){
 
+    init {
+        instance = this
+    }
+
     override fun onCreate() {
         super.onCreate()
         initializeNaverSDK()
     }
 
     companion object{
+        lateinit var instance : App
         val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = APP_NAME)
+        fun getContext(): Context = instance.applicationContext
     }
 
     private fun initializeNaverSDK(){

--- a/Aos/app/src/main/java/com/avengers/nibobnebob/config/AccessTokenInterceptor.kt
+++ b/Aos/app/src/main/java/com/avengers/nibobnebob/config/AccessTokenInterceptor.kt
@@ -1,8 +1,6 @@
 package com.avengers.nibobnebob.config
 
-import android.util.Log
 import com.avengers.nibobnebob.app.DataStoreManager
-import com.avengers.nibobnebob.presentation.util.Constants.ACCESS
 import com.avengers.nibobnebob.presentation.util.Constants.AUTHORIZATION
 import com.avengers.nibobnebob.presentation.util.Constants.BEARER
 import kotlinx.coroutines.flow.first
@@ -18,11 +16,10 @@ class AccessTokenInterceptor @Inject constructor(private val dataStoreManager: D
     @Throws(IOException::class)
     override fun intercept(chain: Interceptor.Chain): Response {
 
-        // 동기가 아닌 비동기로 불러와야한다.. runBlocking말고 다른 방안에 대해 고민
         val accessToken =  runBlocking {
             dataStoreManager.getAccessToken().first()
         }
-        Log.d("토큰 테스트",accessToken.toString())
+
         val builder: Request.Builder = chain.request().newBuilder()
         accessToken?.takeIf { it.isNotEmpty() }?.let {
             builder.addHeader(AUTHORIZATION, "$BEARER $it")

--- a/Aos/app/src/main/java/com/avengers/nibobnebob/config/BearerInterceptor.kt
+++ b/Aos/app/src/main/java/com/avengers/nibobnebob/config/BearerInterceptor.kt
@@ -1,6 +1,8 @@
 package com.avengers.nibobnebob.config
 
 
+import android.content.Intent
+import com.avengers.nibobnebob.app.App
 import com.avengers.nibobnebob.app.DataStoreManager
 import com.avengers.nibobnebob.data.model.BaseState
 import com.avengers.nibobnebob.data.model.request.RefreshTokenRequest
@@ -8,6 +10,7 @@ import com.avengers.nibobnebob.data.model.response.BaseResponse
 import com.avengers.nibobnebob.data.model.response.NaverLoginResponse
 import com.avengers.nibobnebob.data.model.runRemote
 import com.avengers.nibobnebob.data.remote.RefreshApi
+import com.avengers.nibobnebob.presentation.ui.intro.IntroActivity
 import com.avengers.nibobnebob.presentation.util.Constants
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
@@ -48,11 +51,15 @@ class BearerInterceptor @Inject constructor(
                         else -> {
                             dataStoreManager.deleteAccessToken()
                             dataStoreManager.deleteRefreshToken()
+
+                            val intent = Intent(App.getContext(), IntroActivity::class.java)
+                            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                            App.getContext().startActivity(intent)
                         }
                     }
                 }
             }
-            (newAccessToken)?.let {
+            newAccessToken?.let {
                 val newRequest = originalRequest.newBuilder()
                     .addHeader(AUTHORIZATION, "$BEARER $newAccessToken")
                     .build()

--- a/Aos/app/src/main/java/com/avengers/nibobnebob/data/repository/MyPageRepositoryImpl.kt
+++ b/Aos/app/src/main/java/com/avengers/nibobnebob/data/repository/MyPageRepositoryImpl.kt
@@ -8,6 +8,8 @@ import com.avengers.nibobnebob.data.model.response.MyDefaultInfoResponse
 import com.avengers.nibobnebob.data.model.response.MyInfoResponse
 import com.avengers.nibobnebob.data.model.runRemote
 import com.avengers.nibobnebob.data.remote.MyPageApi
+import com.navercorp.nid.oauth.NidOAuthLogin
+import com.navercorp.nid.oauth.OAuthLoginCallback
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
@@ -43,6 +45,15 @@ class MyPageRepositoryImpl @Inject constructor(
             is BaseState.Success -> {
                 dataStoreManager.deleteAccessToken()
                 dataStoreManager.deleteRefreshToken()
+
+                NidOAuthLogin().callDeleteTokenApi(object : OAuthLoginCallback{
+                    override fun onError(errorCode: Int, message: String) {}
+
+                    override fun onFailure(httpStatus: Int, message: String) {}
+
+                    override fun onSuccess() {}
+                })
+
                 emit(result)
             }
 

--- a/Aos/app/src/main/java/com/avengers/nibobnebob/presentation/ui/main/mypage/MyPageFragment.kt
+++ b/Aos/app/src/main/java/com/avengers/nibobnebob/presentation/ui/main/mypage/MyPageFragment.kt
@@ -76,7 +76,6 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>(R.layout.fragment_my_
     }
 
     private fun withDrawConfirm() {
-        Log.d("TEST", "탈퇴 완료")
         viewModel.withdraw()
     }
 

--- a/Aos/app/src/main/java/com/avengers/nibobnebob/presentation/ui/main/mypage/MyPageFragment.kt
+++ b/Aos/app/src/main/java/com/avengers/nibobnebob/presentation/ui/main/mypage/MyPageFragment.kt
@@ -52,8 +52,8 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>(R.layout.fragment_my_
             viewModel.events.collect { event ->
                 when (event) {
                     is MyEditPageEvent.NavigateToIntro -> {
-                        (activity as MainActivity).finish()
                         val intent = Intent(context, IntroActivity::class.java)
+                        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                         startActivity(intent)
                     }
                 }


### PR DESCRIPTION


## 주요 작업
- intent flag 설정하여 IntroActivity 로 전환 로직 수정
- 회원 탈퇴 시  unlink 구현
- BearerInterceptor 에서 access token 재발급 실패 시 IntroActivity 로 전환


## 완료한 task 명세
- 회원 탈퇴 시 네이버 로그인 unlink
- IntroActivity 로의 화면 전환


## 결과 화면



## 리뷰 요청 사항

- BearerInterceptor 에서는 applicationContext 사용하는 로직을 일단 구현했는데 리뷰 부탁!!
- issue 에는 로그아웃/회원 탈퇴 모두 unlink task 가 있는데 로그아웃에서는 unlink 안하는게 자연스러운 것 같아서 구현 제외했어. 혹시 추가해야 할 것 같으면 말해줘! 

related to issue #22 
related to issue #23 
related to issue #86 
