### PR TITLE
[맛집, 위시 맛집 리스트/be] 내 맛집, 위시 맛집 리스트 응답 시 정렬 및 페이징 기능 구현

### DIFF
--- a/be/src/user/user.controller.ts
+++ b/be/src/user/user.controller.ts
@@ -196,10 +196,16 @@ export class UserController {
   @UseGuards(AuthGuard("jwt"))
   @ApiBearerAuth()
   @ApiOperation({ summary: "내 위시 맛집 리스트 정보 가져오기" })
+  @ApiQuery({
+    name: "sort",
+    required: false,
+    type: String,
+    description: "선택된 필터",
+  })
   @ApiResponse({ status: 200, description: "내 맛집 리스트 정보 요청 성공" })
   @ApiResponse({ status: 401, description: "인증 실패" })
-  async getMyWishRestaurantListInfo(@GetUser() tokenInfo: TokenInfo) {
-    return await this.userService.getMyWishRestaurantListInfo(tokenInfo);
+  async getMyWishRestaurantListInfo(@GetUser() tokenInfo: TokenInfo,  @Query('sort') sort: string,) {
+    return await this.userService.getMyWishRestaurantListInfo(tokenInfo,sort);
   }
 
   @ApiTags("Home")
@@ -276,7 +282,6 @@ export class UserController {
     const userInfoDto = plainToClass(UserInfoDto, body);
     const errors = await validate(userInfoDto);
     if (errors.length > 0) {
-      console.log(errors);
       throw new BadRequestException(errors);
     }
     return await this.userService.signup(file, userInfoDto);

--- a/be/src/user/user.controller.ts
+++ b/be/src/user/user.controller.ts
@@ -169,16 +169,24 @@ export class UserController {
     type: String,
     description: "검색 반경",
   })
+  @ApiQuery({
+    name: "sort",
+    required: false,
+    type: String,
+    description: "선택된 필터",
+  })
   @ApiResponse({ status: 200, description: "내 맛집 리스트 정보 요청 성공" })
   @ApiResponse({ status: 401, description: "인증 실패" })
   @ApiResponse({ status: 400, description: "부적절한 요청" })
   async getMyRestaurantListInfo(
     @Query() locationDto: LocationDto,
+    @Query('sort') sort: string,
     @GetUser() tokenInfo: TokenInfo
   ) {
     const searchInfoDto = new SearchInfoDto("", locationDto);
     return await this.userService.getMyRestaurantListInfo(
       searchInfoDto,
+      sort,
       tokenInfo
     );
   }

--- a/be/src/user/user.controller.ts
+++ b/be/src/user/user.controller.ts
@@ -36,6 +36,7 @@ import { FileInterceptor } from "@nestjs/platform-express";
 import { memoryStorage } from 'multer';
 import { plainToClass } from "class-transformer";
 import { validate } from "class-validator";
+import { SortInfoDto } from "src/utils/sortInfo.dto";
 
 const multerOptions = {
   storage: memoryStorage(),
@@ -175,18 +176,21 @@ export class UserController {
     type: String,
     description: "선택된 필터",
   })
+  @ApiQuery({ name: 'page', required: false, description: '페이지 번호' })
+  @ApiQuery({ name: 'limit', required: false, description: '페이지 당 항목 수' })
   @ApiResponse({ status: 200, description: "내 맛집 리스트 정보 요청 성공" })
   @ApiResponse({ status: 401, description: "인증 실패" })
   @ApiResponse({ status: 400, description: "부적절한 요청" })
+  @UsePipes(new ValidationPipe())
   async getMyRestaurantListInfo(
     @Query() locationDto: LocationDto,
-    @Query('sort') sort: string,
+    @Query() sortInfoDto: SortInfoDto,
     @GetUser() tokenInfo: TokenInfo
   ) {
     const searchInfoDto = new SearchInfoDto("", locationDto);
     return await this.userService.getMyRestaurantListInfo(
       searchInfoDto,
-      sort,
+      sortInfoDto,
       tokenInfo
     );
   }
@@ -202,10 +206,12 @@ export class UserController {
     type: String,
     description: "선택된 필터",
   })
+  @ApiQuery({ name: 'page', required: false, description: '페이지 번호' })
+  @ApiQuery({ name: 'limit', required: false, description: '페이지 당 항목 수' })
   @ApiResponse({ status: 200, description: "내 맛집 리스트 정보 요청 성공" })
   @ApiResponse({ status: 401, description: "인증 실패" })
-  async getMyWishRestaurantListInfo(@GetUser() tokenInfo: TokenInfo,  @Query('sort') sort: string,) {
-    return await this.userService.getMyWishRestaurantListInfo(tokenInfo,sort);
+  async getMyWishRestaurantListInfo(@GetUser() tokenInfo: TokenInfo,  @Query() sortInfoDto: SortInfoDto) {
+    return await this.userService.getMyWishRestaurantListInfo(tokenInfo,sortInfoDto);
   }
 
   @ApiTags("Home")

--- a/be/src/user/user.restaurantList.repository.ts
+++ b/be/src/user/user.restaurantList.repository.ts
@@ -5,6 +5,7 @@ import { TokenInfo } from "./user.decorator";
 import { SearchInfoDto } from "src/restaurant/dto/seachInfo.dto";
 import { ReviewInfoEntity } from "src/review/entities/review.entity";
 import { UserWishRestaurantListEntity } from "./entities/user.wishrestaurantlist.entity";
+import { SortInfoDto } from "src/utils/sortInfo.dto";
 
 @Injectable()
 export class UserRestaurantListRepository extends Repository<UserRestaurantListEntity> {
@@ -74,7 +75,7 @@ export class UserRestaurantListRepository extends Repository<UserRestaurantListE
 
   async getMyRestaurantListInfo(
     searchInfoDto: SearchInfoDto,
-    sort: string,
+    sortInfoDto: SortInfoDto,
     id: TokenInfo["id"]
   ) {
     if (searchInfoDto.latitude && searchInfoDto.longitude) {
@@ -129,7 +130,7 @@ export class UserRestaurantListRepository extends Repository<UserRestaurantListE
         { userId: id }
       );
     
-    if (sort === '등록순') {
+    if (sortInfoDto.sort === '등록순') {
       query = query.orderBy("user_restaurant_lists.created_at", "ASC");
     } else {
       query = query.orderBy("user_restaurant_lists.created_at", "DESC");

--- a/be/src/user/user.restaurantList.repository.ts
+++ b/be/src/user/user.restaurantList.repository.ts
@@ -132,7 +132,7 @@ export class UserRestaurantListRepository extends Repository<UserRestaurantListE
         { userId: id }
       );
     
-    if (sortInfoDto.sort === 'TIME ASC') {
+    if (sortInfoDto.sort === 'TIME_ASC') {
       query = query.orderBy("user_restaurant_lists.created_at", "ASC");
     } else {
       query = query.orderBy("user_restaurant_lists.created_at", "DESC");

--- a/be/src/user/user.restaurantList.repository.ts
+++ b/be/src/user/user.restaurantList.repository.ts
@@ -132,7 +132,7 @@ export class UserRestaurantListRepository extends Repository<UserRestaurantListE
         { userId: id }
       );
     
-    if (sortInfoDto.sort === '등록순') {
+    if (sortInfoDto.sort === 'TIME ASC') {
       query = query.orderBy("user_restaurant_lists.created_at", "ASC");
     } else {
       query = query.orderBy("user_restaurant_lists.created_at", "DESC");

--- a/be/src/user/user.restaurantList.repository.ts
+++ b/be/src/user/user.restaurantList.repository.ts
@@ -74,6 +74,7 @@ export class UserRestaurantListRepository extends Repository<UserRestaurantListE
 
   async getMyRestaurantListInfo(
     searchInfoDto: SearchInfoDto,
+    sort: string,
     id: TokenInfo["id"]
   ) {
     if (searchInfoDto.latitude && searchInfoDto.longitude) {
@@ -104,30 +105,37 @@ export class UserRestaurantListRepository extends Repository<UserRestaurantListE
         )
         .getRawMany();
     } else {
-      return await this.createQueryBuilder("user_restaurant_lists")
-        .leftJoinAndSelect("user_restaurant_lists.restaurant", "restaurant")
-        .leftJoin(
-          UserWishRestaurantListEntity,
-          "user_wish_list",
-          "user_wish_list.restaurantId = restaurant.id AND user_wish_list.userId = :userId",
-          { userId: id }
-        )
-        .select([
-          "user_restaurant_lists.restaurantId AS restaurant_id",
-          "restaurant.name",
-          "restaurant.location",
-          "restaurant.address",
-          "restaurant.category",
-          "restaurant.phoneNumber",
-          "restaurant.reviewCnt",
-          "user_restaurant_lists.created_at",
-          `CASE WHEN user_wish_list.userId IS NOT NULL THEN TRUE ELSE FALSE END AS "isWish"`,
-        ])
-        .where(
-          "user_restaurant_lists.user_id = :userId  and user_restaurant_lists.deleted_at IS NULL",
-          { userId: id }
-        )
-        .getRawMany();
+      let query = this.createQueryBuilder("user_restaurant_lists")
+      .leftJoinAndSelect("user_restaurant_lists.restaurant", "restaurant")
+      .leftJoin(
+        UserWishRestaurantListEntity,
+        "user_wish_list",
+        "user_wish_list.restaurantId = restaurant.id AND user_wish_list.userId = :userId",
+        { userId: id }
+      )
+      .select([
+        "user_restaurant_lists.restaurantId AS restaurant_id",
+        "restaurant.name",
+        "restaurant.location",
+        "restaurant.address",
+        "restaurant.category",
+        "restaurant.phoneNumber",
+        "restaurant.reviewCnt",
+        "user_restaurant_lists.created_at",
+        `CASE WHEN user_wish_list.userId IS NOT NULL THEN TRUE ELSE FALSE END AS "isWish"`,
+      ])
+      .where(
+        "user_restaurant_lists.user_id = :userId and user_restaurant_lists.deleted_at IS NULL",
+        { userId: id }
+      );
+    
+    if (sort === '등록순') {
+      query = query.orderBy("user_restaurant_lists.created_at", "ASC");
+    } else {
+      query = query.orderBy("user_restaurant_lists.created_at", "DESC");
+    }
+    
+    return await query.getRawMany();
     }
   }
 }

--- a/be/src/user/user.restaurantList.repository.ts
+++ b/be/src/user/user.restaurantList.repository.ts
@@ -106,9 +106,7 @@ export class UserRestaurantListRepository extends Repository<UserRestaurantListE
         )
         .getRawMany();
 
-      return {
-        items
-      }
+      return items
     } else {
       let query = this.createQueryBuilder("user_restaurant_lists")
       .leftJoinAndSelect("user_restaurant_lists.restaurant", "restaurant")

--- a/be/src/user/user.service.ts
+++ b/be/src/user/user.service.ts
@@ -17,6 +17,7 @@ import { v4 } from "uuid";
 import { User } from "./entities/user.entity";
 import { RestaurantInfoEntity } from "src/restaurant/entities/restaurant.entity";
 import { AuthService } from "src/auth/auth.service";
+import { SortInfoDto } from "src/utils/sortInfo.dto";
 
 @Injectable()
 export class UserService {
@@ -105,13 +106,13 @@ export class UserService {
   }
   async getMyRestaurantListInfo(
     searchInfoDto: SearchInfoDto,
-    sort: string,
+    sortInfoDto: SortInfoDto,
     tokenInfo: TokenInfo
   ) {
     const results =
       await this.userRestaurantListRepository.getMyRestaurantListInfo(
         searchInfoDto,
-        sort,
+        sortInfoDto,
         tokenInfo.id
       );
 
@@ -129,11 +130,11 @@ export class UserService {
 
     return results;
   }
-  async getMyWishRestaurantListInfo(tokenInfo: TokenInfo, sort: string) {
+  async getMyWishRestaurantListInfo(tokenInfo: TokenInfo, sortInfoDto: SortInfoDto) {
     const result =
       await this.userWishRestaurantListRepository.getMyWishRestaurantListInfo(
         tokenInfo.id,
-        sort
+        sortInfoDto
       );
     return result;
   }

--- a/be/src/user/user.service.ts
+++ b/be/src/user/user.service.ts
@@ -116,7 +116,11 @@ export class UserService {
         tokenInfo.id
       );
 
-    for (const restaurant of results.items) {
+    let list
+    if ('items' in results) list = results.items;
+    else list = results;
+
+    for (const restaurant of list) {
       const reviewCount = await this.reviewRepository
         .createQueryBuilder("review")
         .where("review.restaurant_id = :restaurantId", {

--- a/be/src/user/user.service.ts
+++ b/be/src/user/user.service.ts
@@ -105,11 +105,13 @@ export class UserService {
   }
   async getMyRestaurantListInfo(
     searchInfoDto: SearchInfoDto,
+    sort: string,
     tokenInfo: TokenInfo
   ) {
     const results =
       await this.userRestaurantListRepository.getMyRestaurantListInfo(
         searchInfoDto,
+        sort,
         tokenInfo.id
       );
 

--- a/be/src/user/user.service.ts
+++ b/be/src/user/user.service.ts
@@ -116,7 +116,7 @@ export class UserService {
         tokenInfo.id
       );
 
-    for (const restaurant of results) {
+    for (const restaurant of results.items) {
       const reviewCount = await this.reviewRepository
         .createQueryBuilder("review")
         .where("review.restaurant_id = :restaurantId", {

--- a/be/src/user/user.service.ts
+++ b/be/src/user/user.service.ts
@@ -129,10 +129,11 @@ export class UserService {
 
     return results;
   }
-  async getMyWishRestaurantListInfo(tokenInfo: TokenInfo) {
+  async getMyWishRestaurantListInfo(tokenInfo: TokenInfo, sort: string) {
     const result =
       await this.userWishRestaurantListRepository.getMyWishRestaurantListInfo(
-        tokenInfo.id
+        tokenInfo.id,
+        sort
       );
     return result;
   }

--- a/be/src/user/user.wishrestaurantList.repository.ts
+++ b/be/src/user/user.wishrestaurantList.repository.ts
@@ -63,7 +63,21 @@ export class UserWishRestaurantListRepository extends Repository<UserWishRestaur
     } else {
       query = query.orderBy("user_wishrestaurant_lists.created_at", "DESC");
     }
-    
-    return await query.getRawMany();
+
+    sortInfoDto.page = sortInfoDto.page || 1;
+    sortInfoDto.limit = sortInfoDto.limit || 10;
+
+    const offset = (sortInfoDto.page - 1) * sortInfoDto.limit;
+    query = query.skip(offset).take(sortInfoDto.limit + 1);
+  
+    const items = await query.getRawMany();
+  
+    const hasNext = items.length > sortInfoDto.limit;
+    const resultItems = hasNext ? items.slice(0, -1) : items;
+  
+    return {
+      hasNext,
+      items : resultItems,
+    }
   }
 }

--- a/be/src/user/user.wishrestaurantList.repository.ts
+++ b/be/src/user/user.wishrestaurantList.repository.ts
@@ -4,6 +4,7 @@ import { UserWishRestaurantListEntity } from "./entities/user.wishrestaurantlist
 import { TokenInfo } from "./user.decorator";
 import { RestaurantInfoEntity } from "src/restaurant/entities/restaurant.entity";
 import { UserRestaurantListEntity } from "./entities/user.restaurantlist.entity";
+import { SortInfoDto } from "src/utils/sortInfo.dto";
 @Injectable()
 export class UserWishRestaurantListRepository extends Repository<UserWishRestaurantListEntity> {
   constructor(private dataSource: DataSource) {
@@ -32,7 +33,7 @@ export class UserWishRestaurantListRepository extends Repository<UserWishRestaur
     );
     return null;
   }
-  async getMyWishRestaurantListInfo(id: TokenInfo["id"], sort: string) {
+  async getMyWishRestaurantListInfo(id: TokenInfo["id"], sortInfoDto: SortInfoDto) {
     let query = this.createQueryBuilder("user_wishrestaurant_lists")
       .leftJoinAndSelect("user_wishrestaurant_lists.restaurant", "restaurant")
       .leftJoin(
@@ -57,7 +58,7 @@ export class UserWishRestaurantListRepository extends Repository<UserWishRestaur
         { userId: id }
       )
 
-    if (sort === '등록순') {
+    if (sortInfoDto.sort === '등록순') {
       query = query.orderBy("user_wishrestaurant_lists.created_at", "ASC");
     } else {
       query = query.orderBy("user_wishrestaurant_lists.created_at", "DESC");

--- a/be/src/user/user.wishrestaurantList.repository.ts
+++ b/be/src/user/user.wishrestaurantList.repository.ts
@@ -32,8 +32,8 @@ export class UserWishRestaurantListRepository extends Repository<UserWishRestaur
     );
     return null;
   }
-  async getMyWishRestaurantListInfo(id: TokenInfo["id"]) {
-    return await this.createQueryBuilder("user_wishrestaurant_lists")
+  async getMyWishRestaurantListInfo(id: TokenInfo["id"], sort: string) {
+    let query = this.createQueryBuilder("user_wishrestaurant_lists")
       .leftJoinAndSelect("user_wishrestaurant_lists.restaurant", "restaurant")
       .leftJoin(
         UserRestaurantListEntity,
@@ -48,6 +48,7 @@ export class UserWishRestaurantListRepository extends Repository<UserWishRestaur
         "restaurant.address",
         "restaurant.category",
         "restaurant.phoneNumber",
+        "user_wishrestaurant_lists.created_at",
         'CASE WHEN current_url.user_id IS NOT NULL THEN true ELSE false END AS "isMy"',
         'CASE WHEN user_wishrestaurant_lists.user_id IS NOT NULL THEN true ELSE false END AS "isWish"',
       ])
@@ -55,6 +56,13 @@ export class UserWishRestaurantListRepository extends Repository<UserWishRestaur
         `user_wishrestaurant_lists.user_id = :userId and user_wishrestaurant_lists.deleted_at IS NULL`,
         { userId: id }
       )
-      .getRawMany();
+
+    if (sort === '등록순') {
+      query = query.orderBy("user_wishrestaurant_lists.created_at", "ASC");
+    } else {
+      query = query.orderBy("user_wishrestaurant_lists.created_at", "DESC");
+    }
+    
+    return await query.getRawMany();
   }
 }

--- a/be/src/user/user.wishrestaurantList.repository.ts
+++ b/be/src/user/user.wishrestaurantList.repository.ts
@@ -58,7 +58,7 @@ export class UserWishRestaurantListRepository extends Repository<UserWishRestaur
         { userId: id }
       )
 
-    if (sortInfoDto.sort === 'TIME ASC') {
+    if (sortInfoDto.sort === 'TIME_ASC') {
       query = query.orderBy("user_wishrestaurant_lists.created_at", "ASC");
     } else {
       query = query.orderBy("user_wishrestaurant_lists.created_at", "DESC");

--- a/be/src/user/user.wishrestaurantList.repository.ts
+++ b/be/src/user/user.wishrestaurantList.repository.ts
@@ -58,7 +58,7 @@ export class UserWishRestaurantListRepository extends Repository<UserWishRestaur
         { userId: id }
       )
 
-    if (sortInfoDto.sort === '등록순') {
+    if (sortInfoDto.sort === 'TIME ASC') {
       query = query.orderBy("user_wishrestaurant_lists.created_at", "ASC");
     } else {
       query = query.orderBy("user_wishrestaurant_lists.created_at", "DESC");

--- a/be/src/utils/sortInfo.dto.ts
+++ b/be/src/utils/sortInfo.dto.ts
@@ -1,0 +1,20 @@
+import { IsString, IsInt, IsOptional, Min, IsNotEmpty } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class SortInfoDto {
+    @IsString()
+    @IsOptional()
+    sort?: string;
+
+    @IsInt()
+    @Min(1)
+    @Type(() => Number)
+    @IsOptional()
+    page?: number;
+
+    @IsInt()
+    @Min(1)
+    @Type(() => Number)
+    @IsOptional()
+    limit?: number;
+}


### PR DESCRIPTION
## 주요 작업
- 내 맛집, 위시 맛집 리스트 응답 시 정렬 기능 구현
- 내 맛집, 위시 맛집 리스트 응답 시 페이징 기능 구현

## 완료한 task 명세
- [x] 내 맛집, 위시 맛집 리스트 요청 시 필요한 sort, page, limit 정보 DTO로 설정 및 validation
- [x] 내 맛집, 위시 맛집 리스트 응답 시 등록순, 최신순으로 정렬 기능 구현
- [x] 내 맛집, 위시 맛집 리스트 응답 시 입력 받은 페이지 번호에 대한 응답 및 다음 페이지 존재여부 응답
- [x] 내 맛집, 위시 맛집 리스트 응답 시 응답 포맷 형태를 객체 리스트 -> 객체(내부에 items 속성에 객체 리스트) 형태로 변경

Related to Issue #31,#32

